### PR TITLE
Add derive traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ const CMOS_ADDRESS: u16 = 0x70;
 const CMOS_DATA: u16 = 0x71;
 
 /// Struct for storage time
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct Time {
     pub second: u8,
     pub minute: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 //! ```
 #![no_std]
 
+use core::cmp::Ordering;
+
 use x86_64::instructions::port::Port;
 
 /// Selecting a CMOS register port
@@ -27,6 +29,25 @@ pub struct Time {
     pub month: u8,
     pub year: u8,
     pub century: u8,
+}
+
+impl PartialOrd for Time {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Time {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.century
+            .cmp(&other.century)
+            .then(self.year.cmp(&other.year))
+            .then(self.month.cmp(&other.month))
+            .then(self.day.cmp(&other.day))
+            .then(self.hour.cmp(&other.hour))
+            .then(self.minute.cmp(&other.minute))
+            .then(self.second.cmp(&other.second))
+    }
 }
 
 /// Struct for storage ports, current year and century register


### PR DESCRIPTION
Without aiming to replace a proper time library, this adds the following traits for `Time`: `Debug`, `PartialEq`, `Eq`, `Clone`, `Copy`, `Default`, `Ord`, and `PartialOrd`.
It is then easier to perform comparison operations, or simply print the contents for debugging purposes.